### PR TITLE
add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @code42/tbc-bifrost


### PR DESCRIPTION
this file will configure whose approval is required on PR merges (or at least it will once that setting is configured).  They will also automatically be added as reviewers to PRs opened against the repo.  In this case its the bifrost team.  If we want to limit it to specific users that's also possible.