### PR TITLE
BUGFIX: unable to parse timestamp with audit-log download cmd

### DIFF
--- a/incydr/_audit_log/client.py
+++ b/incydr/_audit_log/client.py
@@ -45,8 +45,8 @@ class AuditLogV1:
         actor_ids: Union[List[str], str] = None,
         actor_ip_addresses: Union[List[str], str] = None,
         actor_names: Union[List[str], str] = None,
-        start_time: datetime = None,
-        end_time: datetime = None,
+        start_time: Union[str, datetime] = None,
+        end_time: Union[str, datetime] = None,
         event_types: Union[List[str], str] = None,
         resource_ids: Union[List[str], str] = None,
         user_types: Union[List[UserTypes], UserTypes] = None,
@@ -59,13 +59,13 @@ class AuditLogV1:
         * **page_num**: `int` - page_num number for results, starting at 1.
         * **page_size**: `int` - Max number of results to return per page. Defaults to client's `page_size` setting.
             Maximum page size is 10,000.
-        * **actor_ids**: `List[str]`, `str` - Finds events whose actor_id is one of the given ids.
-        * **actor_ip_addresses**: `List[str]`, `str` - Finds events whose actor_ip_address is one of the given IP addresses.
-        * **actor_names**: `List[str]`, `str` - Finds events whose actor_name is one of the given names.
-        * **start_time**: `datetime` - Search for events within a date range.  Start time for this date range.
-        * **end_time**: `datetime` - Search for events within a date range.  End time for this date range.
-        * **event_types**: `List[str]`, `str` - Finds events whose type is one of the given types.
-        * **resource_ids**: `List[str]`, `str` - Filters searchable events that match resource_id.
+        * **actor_ids**: `List[str] | str` - Finds events whose actor_id is one of the given ids.
+        * **actor_ip_addresses**: `List[str] | str` - Finds events whose actor_ip_address is one of the given IP addresses.
+        * **actor_names**: `List[str] | str` - Finds events whose actor_name is one of the given names.
+        * **start_time**: `datetime | str` - Search for events within a date range.  Start time for this date range.
+        * **end_time**: `datetime | str` - Search for events within a date range.  End time for this date range.
+        * **event_types**: `List[str] | str` - Finds events whose type is one of the given types.
+        * **resource_ids**: `List[str] | str` - Filters searchable events that match resource_id.
         * **user_types**: `List[UserTypes]` - Filters searchable events that match actor type.
 
         **Returns**: A [`AuditEventsPage`][auditeventspage-model] object representing the search response.
@@ -97,8 +97,8 @@ class AuditLogV1:
         actor_ids: Union[List[str], str] = None,
         actor_ip_addresses: Union[List[str], str] = None,
         actor_names: Union[List[str], str] = None,
-        start_time: datetime = None,
-        end_time: datetime = None,
+        start_time: Union[str, datetime] = None,
+        end_time: Union[str, datetime] = None,
         event_types: Union[List[str], str] = None,
         resource_ids: Union[List[str], str] = None,
         user_types: Union[List[UserTypes], UserTypes] = None,
@@ -112,13 +112,13 @@ class AuditLogV1:
 
         **Parameters:**
 
-        * **actor_ids**: `List[str]`, `str` - Finds events whose actor_id is one of the given ids.
-        * **actor_ip_addresses**: `List[str]`, `str` - Finds events whose actor_ip_address is one of the given IP addresses.
-        * **actor_names**: `List[str]`, `str` - Finds events whose actor_name is one of the given names.
-        * **start_time**: `datetime` - Search for events within a date range.  Start time for this date range.
-        * **end_time**: `datetime` - Search for events within a date range.  End time for this date range.
-        * **event_types**: `List[str]`, `str` - Finds events whose type is one of the given types.
-        * **resource_ids**: `List[str]`, `str` - Filters searchable events that match resource_id.
+        * **actor_ids**: `List[str] | str` - Finds events whose actor_id is one of the given ids.
+        * **actor_ip_addresses**: `List[str] | str` - Finds events whose actor_ip_address is one of the given IP addresses.
+        * **actor_names**: `List[str] | str` - Finds events whose actor_name is one of the given names.
+        * **start_time**: `datetime | str` - Search for events within a date range.  Start time for this date range.
+        * **end_time**: `datetime | str` - Search for events within a date range.  End time for this date range.
+        * **event_types**: `List[str] | str` - Finds events whose type is one of the given types.
+        * **resource_ids**: `List[str] | str` - Filters searchable events that match resource_id.
         * **user_types**: `List[UserTypes]` - Filters searchable events that match actor type.
 
         **Returns**: A [`AuditEventsPage`][auditeventspage-model] object representing the search response.
@@ -149,8 +149,8 @@ class AuditLogV1:
         actor_ids: Union[List[str], str] = None,
         actor_ip_addresses: Union[List[str], str] = None,
         actor_names: Union[List[str], str] = None,
-        start_time: datetime = None,
-        end_time: datetime = None,
+        start_time: Union[str, datetime] = None,
+        end_time: Union[str, datetime] = None,
         event_types: Union[List[str], str] = None,
         resource_ids: Union[List[str], str] = None,
         user_types: Union[List[UserTypes], UserTypes] = None,
@@ -162,13 +162,13 @@ class AuditLogV1:
 
         * **page_num**: `int` - Page number for results, starting at 1.
         * **page_size**: `int` - Max number of results to return per page.
-        * **actor_ids**: `List[str]`, `str` - Finds events whose actor_id is one of the given ids.
-        * **actor_ip_addresses**: `List[str]`, `str` - Finds events whose actor_ip_address is one of the given IP addresses.
-        * **actor_names**: `List[str]`, `str` - Finds events whose actor_name is one of the given names.
-        * **start_time**: `datetime` - Search for events within a date range.  Start time for this date range.
-        * **end_time**: `datetime` - Search for events within a date range.  End time for this date range.
-        * **event_types**: `List[str]`, `str` - Finds events whose type is one of the given types.
-        * **resource_ids**: `List[str]`, `str` - Filters searchable events that match resource_id.
+        * **actor_ids**: `List[str] | str` - Finds events whose actor_id is one of the given ids.
+        * **actor_ip_addresses**: `List[str] | str` - Finds events whose actor_ip_address is one of the given IP addresses.
+        * **actor_names**: `List[str] | str` - Finds events whose actor_name is one of the given names.
+        * **start_time**: `datetime | str` - Search for events within a date range.  Start time for this date range.
+        * **end_time**: `datetime | str` - Search for events within a date range.  End time for this date range.
+        * **event_types**: `List[str] | str` - Finds events whose type is one of the given types.
+        * **resource_ids**: `List[str] | str` - Filters searchable events that match resource_id.
         * **user_types**: `List[UserTypes]` - Filters searchable events that match actor type.
 
         **Returns**: An `int` indicating the number of resulting audit log events from search.
@@ -201,8 +201,8 @@ class AuditLogV1:
         actor_ids: Union[List[str], str] = None,
         actor_ip_addresses: Union[List[str], str] = None,
         actor_names: Union[List[str], str] = None,
-        start_time: datetime = None,
-        end_time: datetime = None,
+        start_time: Union[str, datetime] = None,
+        end_time: Union[str, datetime] = None,
         event_types: Union[List[str], str] = None,
         resource_ids: Union[List[str], str] = None,
         user_types: Union[List[UserTypes], UserTypes] = None,
@@ -214,13 +214,13 @@ class AuditLogV1:
 
         * **target_folder**: `Path, str` - A string or `pathlib.Path` object that represents the folder
         which the file will be saved to.
-        * **actor_ids**: `List[str]`, `str` - Finds events whose actor_id is one of the given ids.
-        * **actor_ip_addresses**: `List[str]`, `str` - Finds events whose actor_ip_address is one of the given IP addresses.
-        * **actor_names**: `List[str]`, `str` - Finds events whose actor_name is one of the given names.
-        * **start_time**: `datetime` - Search for events within a date range.  Start time for this date range.
-        * **end_time**: `datetime` - Search for events within a date range.  End time for this date range.
-        * **event_types**: `List[str]`, `str` - Finds events whose type is one of the given types.
-        * **resource_ids**: `List[str]`, `str` - Filters searchable events that match resource_id.
+        * **actor_ids**: `List[str] | str` - Finds events whose actor_id is one of the given ids.
+        * **actor_ip_addresses**: `List[str] | str` - Finds events whose actor_ip_address is one of the given IP addresses.
+        * **actor_names**: `List[str] | str` - Finds events whose actor_name is one of the given names.
+        * **start_time**: `datetime | str` - Search for events within a date range.  Start time for this date range.
+        * **end_time**: `datetime | str` - Search for events within a date range.  End time for this date range.
+        * **event_types**: `List[str] | str` - Finds events whose type is one of the given types.
+        * **resource_ids**: `List[str] | str` - Filters searchable events that match resource_id.
         * **user_types**: `List[UserTypes]` - Filters searchable events that match actor type.
 
         **Returns**: A `pathlib.Path` object representing location of the downloaded csv file.
@@ -228,9 +228,9 @@ class AuditLogV1:
 
         date_range = DateRange()
         if start_time:
-            date_range.startTime = start_time.timestamp()
+            date_range.startTime = parse_timestamp_to_posix_timestamp(start_time)
         if end_time:
-            date_range.endTime = end_time.timestamp()
+            date_range.endTime = parse_timestamp_to_posix_timestamp(end_time)
 
         data = QueryExportRequest(
             actorIds=[actor_ids] if isinstance(actor_ids, str) else actor_ids,
@@ -274,8 +274,8 @@ def _build_query_request(
     actor_ids: Union[List[str], str] = None,
     actor_ip_addresses: Union[List[str], str] = None,
     actor_names: Union[List[str], str] = None,
-    start_time: datetime = None,
-    end_time: datetime = None,
+    start_time: Union[str, datetime] = None,
+    end_time: Union[str, datetime] = None,
     event_types: Union[List[str], str] = None,
     resource_ids: Union[List[str], str] = None,
     user_types: Union[List[UserTypes], UserTypes] = None,


### PR DESCRIPTION
Updates the `audit-log download` method to be able to parse a POSIX timestamp from a string in addition to a `datetime` object.

also minor doc string updates