### PR TITLE
BUGFIX: remove audit/search-results-export api

### DIFF
--- a/docs/cli/audit_log.md
+++ b/docs/cli/audit_log.md
@@ -6,4 +6,4 @@
 
 ::: mkdocs-click
     :module: incydr.cli.cmds.audit_log
-    :command: list_
+    :command: download

--- a/incydr/_audit_log/client.py
+++ b/incydr/_audit_log/client.py
@@ -92,56 +92,6 @@ class AuditLogV1:
 
         return AuditEventsPage.parse_response(response)
 
-    def search_events(
-        self,
-        actor_ids: Union[List[str], str] = None,
-        actor_ip_addresses: Union[List[str], str] = None,
-        actor_names: Union[List[str], str] = None,
-        start_time: Union[str, datetime] = None,
-        end_time: Union[str, datetime] = None,
-        event_types: Union[List[str], str] = None,
-        resource_ids: Union[List[str], str] = None,
-        user_types: Union[List[UserTypes], UserTypes] = None,
-    ) -> AuditEventsPage:
-        """
-        Search audit log entries, specifically for large return sets without paging.
-
-        Returns up to 100,000 events that match the search criteria provided.
-
-        Default: returns most recent 100,000 events.
-
-        **Parameters:**
-
-        * **actor_ids**: `List[str] | str` - Finds events whose actor_id is one of the given ids.
-        * **actor_ip_addresses**: `List[str] | str` - Finds events whose actor_ip_address is one of the given IP addresses.
-        * **actor_names**: `List[str] | str` - Finds events whose actor_name is one of the given names.
-        * **start_time**: `datetime | str` - Search for events within a date range.  Start time for this date range.
-        * **end_time**: `datetime | str` - Search for events within a date range.  End time for this date range.
-        * **event_types**: `List[str] | str` - Finds events whose type is one of the given types.
-        * **resource_ids**: `List[str] | str` - Filters searchable events that match resource_id.
-        * **user_types**: `List[UserTypes]` - Filters searchable events that match actor type.
-
-        **Returns**: A [`AuditEventsPage`][auditeventspage-model] object representing the search response.
-        """
-
-        request = _build_query_request(
-            page_num=0,
-            page_size=0,
-            actor_ids=actor_ids,
-            actor_ip_addresses=actor_ip_addresses,
-            actor_names=actor_names,
-            start_time=start_time,
-            end_time=end_time,
-            event_types=event_types,
-            resource_ids=resource_ids,
-            user_types=user_types,
-        )
-        response = self._parent.session.post(
-            "/v1/audit/search-results-export", json=request.dict()
-        )
-
-        return AuditEventsPage.parse_response(response)
-
     def get_event_count(
         self,
         page_num: int = 0,

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -129,15 +129,6 @@ def test_get_page_when_all_params_returns_expected_data(
     assert page.pagination_range_end_index == len(page.events) == 2
 
 
-def test_search_events_when_default_params_returns_expected_data(mock_export):
-    client = Client()
-    page = client.audit_log.v1.search_events()
-    assert isinstance(page, AuditEventsPage)
-    assert page.events[0] == TEST_AL_ENTRY_1
-    assert page.events[1] == TEST_AL_ENTRY_2
-    assert page.pagination_range_end_index == len(page.events) == 2
-
-
 def test_get_events_count_when_default_params_returns_expected_data(
     httpserver_auth: HTTPServer,
 ):
@@ -239,68 +230,7 @@ def test_cli_search_when_custom_params_makes_expected_call(
     assert result.exit_code == 0
 
 
-def test_cli_list_when_default_params_makes_expected_call(
-    httpserver_auth: HTTPServer, runner, mock_export
-):
-    result = runner.invoke(incydr, ["audit-log", "list"])
-    httpserver_auth.check()
-    assert result.exit_code == 0
-
-
-def test_cli_list_when_custom_params_makes_expected_call(
-    runner, httpserver_auth: HTTPServer
-):
-    audit_events_data = {
-        "events": [
-            TEST_AL_ENTRY_1,
-            TEST_AL_ENTRY_2,
-        ],
-        "pagination_range_start_index": 0,
-        "pagination_range_end_index": 2,
-    }
-    data = {
-        "actorIds": ["foo", "bar"],
-        "actorIpAddresses": ["foo1", "bar1"],
-        "actorNames": ["foo2", "bar2"],
-        "dateRange": {"endTime": 1666296001.0, "startTime": 1662768000.0},
-        "eventTypes": ["foo3", "bar3"],
-        "pageNum": 0,
-        "pageSize": 0,
-        "resourceIds": ["foo4", "bar4"],
-        "userTypes": ["USER"],
-    }
-    httpserver_auth.expect_request(
-        "/v1/audit/search-results-export", method="POST", json=data
-    ).respond_with_json(audit_events_data)
-
-    result = runner.invoke(
-        incydr,
-        [
-            "audit-log",
-            "list",
-            "--start",
-            "2022-09-10",
-            "--end",
-            "2022-10-20 20:00:01",
-            "--actor-ids",
-            "foo,bar",
-            "--actor-ip-addresses",
-            "foo1,bar1",
-            "--actor-names",
-            "foo2,bar2",
-            "--event-types",
-            "foo3,bar3",
-            "--resource-ids",
-            "foo4,bar4",
-            "--user-types",
-            "USER",
-        ],
-    )
-    httpserver_auth.check()
-    assert result.exit_code == 0
-
-
-def test_cli_list_when_download_makes_expected_call(
+def test_cli_download_makes_expected_call(
     runner, httpserver_auth: HTTPServer, tmp_path
 ):
     export_event_data = {
@@ -329,8 +259,6 @@ def test_cli_list_when_download_makes_expected_call(
         "/v1/audit/redeemDownloadToken", query_string=export_event_data
     ).respond_with_json(redeem_events_data)
 
-    result = runner.invoke(
-        incydr, ["audit-log", "list", "--download", "--path", tmp_path]
-    )
+    result = runner.invoke(incydr, ["audit-log", "download", "--path", tmp_path])
     httpserver_auth.check()
     assert result.exit_code == 0


### PR DESCRIPTION
Removes the `/search-results-export` api from the SDK.  This API runs into issues with timing out due to the dev portal's ocelot settings, and it provides the same functionality as `/search-audit-log` but without paging.

Changes the `audit-log list` command to `audit-log download`