### PR TITLE
add devices commands; minor output refactoring

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -1,0 +1,9 @@
+# Devices Commands
+
+::: mkdocs-click
+    :module: incydr.cli.cmds.devices
+    :command: list_
+
+::: mkdocs-click
+    :module: incydr.cli.cmds.devices
+    :command: show

--- a/incydr/cli/cmds/alerts.py
+++ b/incydr/cli/cmds/alerts.py
@@ -109,27 +109,26 @@ def search(
         )
         return
     if format_ == TableFormat.table:
-        if not columns:
-            columns = [
-                "created_at",
-                "risk_severity",
-                "state",
-                "actor",
-                "actor_id",
-                "name",
-                "description",
-                "watchlists",
-                "state_last_modified_by",
-                "state_last_modified_at",
-                "id",
-            ]
+        columns = columns or [
+            "created_at",
+            "risk_severity",
+            "state",
+            "actor",
+            "actor_id",
+            "name",
+            "description",
+            "watchlists",
+            "state_last_modified_by",
+            "state_last_modified_at",
+            "id",
+        ]
         render.table(AlertSummary, alert_summaries, columns=columns, flat=False)
     elif format_ == TableFormat.csv:
         render.csv(AlertSummary, alert_summaries, columns=columns, flat=True)
     elif format_ == TableFormat.json:
         for alert in alert_summaries:
             console.print_json(alert.json())
-    else:
+    else:  # raw-json
         for alert in alert_summaries:
             click.echo(alert.json())
 
@@ -149,7 +148,7 @@ def show(ctx: Context, alert_id: str, format_: SingleFormat):
         console.print(Panel.fit(model_as_card(alert)))
     elif format_ == SingleFormat.json:
         console.print_json(alert.json())
-    else:
+    else:  # raw-json
         click.echo(alert.json())
 
 

--- a/incydr/cli/cmds/departments.py
+++ b/incydr/cli/cmds/departments.py
@@ -51,4 +51,4 @@ def list_(ctx: Context, format_: SingleFormat, name: Optional[str] = None):
     elif format_ == SingleFormat.json:
         console.print_json(data=deps)
     else:
-        console.print(json.dumps(deps), highlight=False)
+        click.echo(json.dumps(deps))

--- a/incydr/cli/cmds/devices.py
+++ b/incydr/cli/cmds/devices.py
@@ -1,0 +1,98 @@
+import click
+from click import Context
+from rich.panel import Panel
+
+from incydr._devices.models import Device
+from incydr.cli import console
+from incydr.cli import init_client
+from incydr.cli import log_file_option
+from incydr.cli import log_level_option
+from incydr.cli import render
+from incydr.cli.cmds.options.output_options import columns_option
+from incydr.cli.cmds.options.output_options import single_format_option
+from incydr.cli.cmds.options.output_options import SingleFormat
+from incydr.cli.cmds.options.output_options import table_format_option
+from incydr.cli.cmds.options.output_options import TableFormat
+from incydr.cli.core import IncydrCommand
+from incydr.cli.core import IncydrGroup
+from incydr.utils import model_as_card
+
+
+@click.group(cls=IncydrGroup)
+@log_level_option
+@log_file_option
+@click.pass_context
+def devices(ctx, log_level, log_file):
+    """View devices."""
+    init_client(ctx, log_level, log_file)
+
+
+@devices.command("list", cls=IncydrCommand)
+@click.option(
+    "--active/--inactive",
+    default=None,
+    help="Filter by active or inactive devices. Defaults to returning both when when neither option is passed.",
+)
+@click.option(
+    "--blocked/--unblocked",
+    default=None,
+    help="Filter by blocked or unblocked devices. Defaults to returning both when when neither option is passed.",
+)
+@table_format_option
+@columns_option
+@click.pass_context
+def list_(
+    ctx: Context,
+    active: bool = None,
+    blocked: bool = None,
+    format_: TableFormat = None,
+    columns: str = None,
+):
+    """
+    List devices.
+    """
+    client = ctx.obj()
+    devices = client.devices.v1.iter_all(active, blocked)
+
+    if format_ == TableFormat.table:
+        columns = columns or [
+            "device_id",
+            "name",
+            "os_hostname",
+            "status",
+            "active",
+            "blocked",
+            "alert_state",
+            "org_guid",
+            "login_date",
+        ]
+        render.table(Device, devices, columns=columns, flat=False)
+    elif format_ == TableFormat.csv:
+        render.csv(Device, devices, columns=columns, flat=True)
+    elif format_ == TableFormat.json:
+        for device in devices:
+            console.print_json(device.json())
+    else:
+        for device in devices:
+            click.echo(device.json())
+
+
+@devices.command(cls=IncydrCommand)
+@click.argument("device_id")
+@single_format_option
+@click.pass_context
+def show(ctx: Context, device_id: str, format_: SingleFormat = None):
+    """
+    Show details for a single device.
+    """
+    client = ctx.obj()
+    device = client.devices.v1.get_device(device_id)
+
+    if format_ == SingleFormat.rich and client.settings.use_rich:
+        console.print(
+            Panel.fit(model_as_card(device), title=f"Device {device.device_id}")
+        )
+    elif format_ == SingleFormat.json:
+        console.print_json(device.json())
+    else:  # format == "raw-json"
+        click.echo(device.json())

--- a/incydr/cli/cmds/directory_groups.py
+++ b/incydr/cli/cmds/directory_groups.py
@@ -37,10 +37,9 @@ def list_(ctx: Context, format_: TableFormat, name: Optional[str] = None):
 
     The results can then be used with the watchlists commands to automatically assign users to watchlists by directory group.
     """
-    if not format_:
-        format_ = TableFormat.table
     client = ctx.obj()
     groups = client.directory_groups.v1.iter_all(name=name)
+
     if format_ == TableFormat.table:
         render.table(DirectoryGroup, groups)
     elif format_ == TableFormat.csv:
@@ -50,4 +49,4 @@ def list_(ctx: Context, format_: TableFormat, name: Optional[str] = None):
             console.print_json(group.json())
     else:
         for group in groups:
-            console.print(group.json(), highlight=False)
+            click.echo(group.json())

--- a/incydr/cli/cmds/users.py
+++ b/incydr/cli/cmds/users.py
@@ -67,21 +67,20 @@ def list_(
     client = ctx.obj()
     users_ = client.users.v1.iter_all(active=active, blocked=blocked, username=username)
 
-    columns = columns or [
-        "user_id",
-        "username",
-        "first_name",
-        "last_name",
-        "org_guid",
-        "org_name",
-        "notes",
-        "active",
-        "blocked",
-    ]
-
     if format_ == TableFormat.csv:
         render.csv(User, users_, columns=columns, flat=True)
     elif format_ == TableFormat.table:
+        columns = columns or [
+            "user_id",
+            "username",
+            "first_name",
+            "last_name",
+            "org_guid",
+            "org_name",
+            "notes",
+            "active",
+            "blocked",
+        ]
         render.table(User, users_, columns=columns, flat=False)
     else:
         printed = False
@@ -115,7 +114,7 @@ def show(ctx: Context, user, format_: SingleFormat):
     elif format_ == SingleFormat.json:
         console.print_json(user.json())
     else:  # format == "raw-json"
-        console.print(user.json(), highlight=False)
+        click.echo(user.json())
 
 
 @users.command(cls=IncydrCommand)
@@ -130,28 +129,27 @@ def list_devices(ctx: Context, user, format_: TableFormat, columns: str = None):
     client = ctx.obj()
     devices = client.users.v1.get_devices(user).devices
 
-    columns = columns or [
-        "device_id",
-        "name",
-        "os_hostname",
-        "status",
-        "active",
-        "blocked",
-        "alert_state",
-        "org_guid",
-        "login_date",
-    ]
-
     if format_ == TableFormat.csv:
         render.csv(Device, devices, columns=columns, flat=True)
     elif format_ == TableFormat.table:
+        columns = columns or [
+            "device_id",
+            "name",
+            "os_hostname",
+            "status",
+            "active",
+            "blocked",
+            "alert_state",
+            "org_guid",
+            "login_date",
+        ]
         render.table(Device, devices, columns=columns, flat=False)
     elif format_ == TableFormat.json:
         for item in devices:
             console.print_json(item.json())
-    else:  # format == "raw-json"/TableFormat.raw_json
+    else:  # raw-json
         for item in devices:
-            console.print(item.json(), highlight=False)
+            click.echo(item.json())
 
 
 @users.command(cls=IncydrCommand)
@@ -173,9 +171,9 @@ def list_roles(ctx: Context, user: str, format_: TableFormat, columns: str = Non
     elif format_ == TableFormat.json:
         for item in roles:
             console.print_json(item.json())
-    else:  # format == "raw-json"/TableFormat.raw_json
+    else:  # raw-json
         for item in roles:
-            console.print(item.json(), highlight=False)
+            click.echo(item.json())
 
 
 @users.command(cls=IncydrCommand)
@@ -196,6 +194,7 @@ def update_roles(ctx: Context, user, roles):
     """
     client = ctx.obj()
     client.users.v1.update_roles(user, roles.split(","))
+    console.print(f"Roles successfully updated for user '{user}'")
 
 
 # TODO: add-role. blocked by INTEG-2298
@@ -212,6 +211,7 @@ def activate(ctx: Context, user):
     """
     client = ctx.obj()
     client.users.v1.activate(user)
+    console.print(f"User '{user}' successfully activated.")
 
 
 @users.command(cls=IncydrCommand)
@@ -223,6 +223,7 @@ def deactivate(ctx: Context, user):
     """
     client = ctx.obj()
     client.users.v1.deactivate(user)
+    console.print(f"User '{user}' successfully deactivated.")
 
 
 @users.command(cls=IncydrCommand)
@@ -235,6 +236,7 @@ def move(ctx: Context, user, org_guid):
     """
     client = ctx.obj()
     client.users.v1.move(user, org_guid)
+    console.print(f"User '{user}' successfully moved to org '{org_guid}'.")
 
 
 @users.command(cls=IncydrCommand)

--- a/incydr/cli/main.py
+++ b/incydr/cli/main.py
@@ -12,6 +12,7 @@ from incydr.cli.cmds.alerts import alerts
 from incydr.cli.cmds.audit_log import audit_log
 from incydr.cli.cmds.cases import cases
 from incydr.cli.cmds.departments import departments
+from incydr.cli.cmds.devices import devices
 from incydr.cli.cmds.directory_groups import directory_groups
 from incydr.cli.cmds.file_events import file_events
 from incydr.cli.cmds.user_risk_profiles import risk_profiles
@@ -37,6 +38,7 @@ def incydr(ctx, log_level, log_file):
 incydr.add_command(alerts)
 incydr.add_command(audit_log)
 incydr.add_command(departments)
+incydr.add_command(devices)
 incydr.add_command(directory_groups)
 incydr.add_command(file_events)
 incydr.add_command(cases, name="cases")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Audit Log: 'cli/audit_log.md'
       - Cases: 'cli/cases.md'
       - Departments: 'cli/departments.md'
+      - Devices: 'cli/devices.md'
       - Directory Groups: 'cli/directory_groups.md'
       - File Events: 'cli/file_events.md'
       - User Risk Profiles: 'cli/user_risk_profiles.md'


### PR DESCRIPTION
Adds `devices list` and `devices show <id>` commands.

Does a bunch of small refactoring, mostly:

- use `click.echo` when outputting raw json
- print success messages to console
- only set column defaults when `table` format, CSV defaults to all columns