### PR TITLE
add role commands

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,3 +25,4 @@ per-file-ignores =
     incydr/_core/settings.py: B902
     incydr/_queries/_file_events/enums.py: B902
     incydr/cli/*: B008
+    incydr/utils.py: B905

--- a/incydr/_users/client.py
+++ b/incydr/_users/client.py
@@ -221,7 +221,10 @@ class UsersV1:
         **Returns**: A [`UpdateRolesResponse`][updaterolesresponse-model] object.
         """
         roles = self._update_role_ids_for_user(roles, user_id, add=True)
-        return self.update_roles(user_id, roles)
+        response = self._parent.session.put(
+            f"/v1/users/{user_id}/roles", json={"roleIds": roles}
+        )
+        return UpdateRolesResponse.parse_response(response)
 
     def remove_roles(
         self, user_id: str, roles: Union[str, List[str]]
@@ -235,7 +238,10 @@ class UsersV1:
         * **roles**: `str | List[str]` The roles to remove from the user. Accepts either role IDs or role names."
         """
         roles = self._update_role_ids_for_user(roles, user_id, add=False)
-        return self.update_roles(user_id, roles)
+        response = self._parent.session.put(
+            f"/v1/users/{user_id}/roles", json={"roleIds": roles}
+        )
+        return UpdateRolesResponse.parse_response(response)
 
     def move(self, user_id: str, org_guid: str) -> Response:
         """
@@ -302,7 +308,7 @@ class UsersV1:
         )
         return Role.parse_response(response)
 
-    def _get_id_by_name(self, name: str):
+    def _get_id_by_name(self, role_name: str):
         """
         Get a role ID by its name.
 
@@ -310,8 +316,10 @@ class UsersV1:
         """
         if not self._available_roles:
             self._lookup_roles()
-        keys = self._available_roles.keys()
-        return self._available_roles.get(name) if name in keys else name
+        for name, id_ in self._available_roles.items():
+            if (role_name == name) or (role_name == id_):
+                return id_
+        raise RoleNotFoundError(role_name)
 
     def _update_role_ids_for_user(self, roles, user_id, add=True):
         """
@@ -322,6 +330,8 @@ class UsersV1:
 
         Returns the updated list of role IDs for a user.
         """
+        errors = []
+
         role_ids = [i.role_id for i in self.list_user_roles(user_id)]
 
         if not self._available_roles:
@@ -331,20 +341,22 @@ class UsersV1:
             roles = [roles]
 
         for role in roles:
-            found = False
-            for name, id_ in self._available_roles.items():
-                if (role == name) or (role == id_):
-                    found = True
-                    if add:
-                        role_ids.append(id_)
-                    else:
-                        try:
-                            role_ids.remove(id_)
-                        except ValueError:
-                            raise UserNotAssignedRoleError(id_)
-                    break
-            if not found:
-                raise RoleNotFoundError(role)
+            try:
+                id_ = self._get_id_by_name(role)
+            except RoleNotFoundError as err:
+                errors.append(err)
+                continue
+            if add:
+                role_ids.append(id_)
+            else:
+                try:
+                    role_ids.remove(id_)
+                except ValueError:
+                    errors.append(UserNotAssignedRoleError(id_))
+
+        if errors:
+            raise RoleProcessingError(errors)
+
         return role_ids
 
     def _lookup_roles(self):
@@ -353,6 +365,30 @@ class UsersV1:
         available_roles = self.list_roles()
         for r in available_roles:
             self._available_roles[r.role_name] = r.role_id
+
+
+class RoleProcessingError(Exception):
+    """
+    Outputs list of errors that arose during processing.
+
+    Example output:
+        incydr._users.client.RoleProcessingError: The following errors arose during role processing:
+            * User is not currently assigned the following role: 'alert-emails'. Role cannot be removed.
+            * No role matching the following was found: 'fake', or you do not have permission to assign this role.
+    """
+
+    def __init__(self, errors):
+        message = (
+            "The following errors arose during role processing:\n\t* "
+            + "\n\t* ".join([str(e) for e in errors])
+        )
+        super().__init__(message)
+        self._errors = errors
+
+    @property
+    def errors(self):
+        """List of errors that arose during role processing."""
+        return self._errors
 
 
 class UserNotAssignedRoleError(Exception):
@@ -369,7 +405,7 @@ class UserNotAssignedRoleError(Exception):
 
 class RoleNotFoundError(Exception):
     def __init__(self, role):
-        message = f"No role matching the following was found: '{role}', or you do not have permission to assign this role. Roles can be specified by name (case-sensitive) or ID."
+        message = f"No role matching the following was found: '{role}', or you do not have permission to assign this role. Roles can be specified by case-sensitive name (ie. 'Cloud Admin') or ID (ie. cloud-admin)."
         super().__init__(message)
         self._role = role
 

--- a/incydr/cli/cmds/alerts.py
+++ b/incydr/cli/cmds/alerts.py
@@ -21,6 +21,7 @@ from incydr.cli import render
 from incydr.cli.cmds.options.alert_filter_options import advanced_query_option
 from incydr.cli.cmds.options.alert_filter_options import filter_options
 from incydr.cli.cmds.options.output_options import columns_option
+from incydr.cli.cmds.options.output_options import input_format_option
 from incydr.cli.cmds.options.output_options import output_options
 from incydr.cli.cmds.options.output_options import single_format_option
 from incydr.cli.cmds.options.output_options import SingleFormat
@@ -185,14 +186,7 @@ def update_state(ctx: Context, alert_id: str, state: str, note: str = None):
 
 @alerts.command(cls=IncydrCommand)
 @click.argument("file", type=AutoDecodedFile())
-@click.option(
-    "--format",
-    "-f",
-    "format_",
-    type=click.Choice(["csv", "json-lines"]),
-    default="csv",
-    help="Specify format of input file.",
-)
+@input_format_option
 @click.option(
     "--state",
     type=click.Choice(["OPEN", "RESOLVED", "IN_PROGRESS", "PENDING"]),

--- a/incydr/cli/cmds/cases.py
+++ b/incydr/cli/cmds/cases.py
@@ -392,7 +392,6 @@ def download(
 @cases.group(cls=IncydrGroup)
 def file_events():
     """View and update file events associated with a case."""
-    pass
 
 
 @file_events.command("show", cls=IncydrCommand)

--- a/incydr/cli/cmds/options/output_options.py
+++ b/incydr/cli/cmds/options/output_options.py
@@ -19,6 +19,15 @@ class SingleFormat(str, Enum):
     raw_json = "raw-json"
 
 
+input_format_option = click.option(
+    "--format",
+    "-f",
+    "format_",
+    type=click.Choice(["csv", "json-lines"]),
+    default="csv",
+    help="Specify format of input file.",
+)
+
 table_format_option = click.option(
     "--format",
     "-f",

--- a/incydr/cli/cmds/options/output_options.py
+++ b/incydr/cli/cmds/options/output_options.py
@@ -25,7 +25,7 @@ input_format_option = click.option(
     "format_",
     type=click.Choice(["csv", "json-lines"]),
     default="csv",
-    help="Specify format of input file.",
+    help="Specify format of input file: 'csv' or 'json-lines'.  Defaults to 'csv'.",
 )
 
 table_format_option = click.option(

--- a/incydr/utils.py
+++ b/incydr/utils.py
@@ -130,6 +130,8 @@ def list_as_panel(
         ╰───────────╯
     """
     if sep:
+        # zip has an added `strict=False` kwarg as of python 3.10
+        # flake8's B905 error will call this out, suppressed for now for backwards compatibility with <3.10
         items = list(chain(*zip(items, repeat(sep))))[:-1]
     return Panel(Group(*items), title=title, expand=expand, box=box)
 

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -657,8 +657,6 @@ def test_cli_show_makes_expected_call(
     ).respond_with_json(TEST_WATCHLIST_1)
 
     result = runner.invoke(incydr, ["watchlists", "show", watchlist_input])
-    print(result)
-    print(result.output)
     httpserver_auth.check()
     assert result.exit_code == 0
 


### PR DESCRIPTION
Adds the `roles show` and `roles list` commands to the `users` command group.  

Adds `--add` and `--remove` flags to the `update-roles` and `bulk-update-roles` commands.

All role write operations accept role names or role IDs.