### PR TITLE
BUGFIX; Syslogging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         - id: pyupgrade
           args: ["--py37-plus", "--keep-runtime-typing"]
     - repo: https://github.com/asottile/reorder_python_imports
-      rev: v3.8.2
+      rev: v3.9.0
       hooks:
         - id: reorder-python-imports
           args: ["--py37-plus", "--application-directories=.:incydr:tests"]

--- a/docs/cli/syslogging.md
+++ b/docs/cli/syslogging.md
@@ -1,0 +1,35 @@
+# Syslogging
+
+Use the `--output` option with `file-events`, `alerts`, or `audit-log` queries to log the resulting data to a server.
+
+The receiving server can be specified in one of the following formats:
+
+* `PROTOCOL:HOSTNAME:PORT`
+* `HOSTNAME:PORT`
+* `HOSTNAME`
+
+`PROTOCOL` defaults to TCP, `PORT` defaults to 601.
+
+Available `PROTOCOL` values are as follows:
+
+* `TCP`
+* `UDP`
+* `TLS-TCP`
+
+!!! note
+    TCP protocol is recommended because Incydr's logging messages will often be larger than the max size for UDP protocol.
+    Using UDP protocol may result in data being truncated.
+
+## Example Commands
+
+The following command will send the file-events from the past 5 days to the 601 port at the `syslog.example.com` server via TCP protocol.
+
+```bash
+incydr file-events search --start P5D --output syslog.example.com
+```
+
+Specifying all values for the `output` option would look as follows:
+
+```bash
+--output TCP:syslog.example.com:601
+```

--- a/src/_cli/__init__.py
+++ b/src/_cli/__init__.py
@@ -59,7 +59,7 @@ log_file_option = click.option(
 log_stderr_option = click.option(
     "--log-stderr",
     "log_stderr",
-    help="Silence logging to stderr.",
+    help="Enable logging to stderr.",
     default=False,
     is_flag=True,
     callback=log_stderr_callback,

--- a/src/_cli/cmds/alerts.py
+++ b/src/_cli/cmds/alerts.py
@@ -126,6 +126,12 @@ def search(
         alerts_gen = _update_checkpoint(cursor, checkpoint_name, alerts_gen)
 
     with warn_interrupt() if checkpoint_name else nullcontext():
+        if output:
+            logger = get_server_logger(output, certs, ignore_cert_validation)
+            for alert_ in alerts_gen:
+                logger.info(alert_.json())
+            return
+
         if format_ == TableFormat.table:
             columns = columns or [
                 "created_at",
@@ -149,9 +155,6 @@ def search(
                 printed = True
                 if format_ == TableFormat.json_pretty:
                     console.print_json(alert_.json())
-                elif output:
-                    logger = get_server_logger(output, certs, ignore_cert_validation)
-                    logger.info(alert_.json())
                 else:
                     click.echo(alert_.json())
             if not printed:

--- a/src/_cli/cmds/audit_log.py
+++ b/src/_cli/cmds/audit_log.py
@@ -146,6 +146,12 @@ def search(
         events_gen = _update_checkpoint(cursor, checkpoint_name, events_gen)
 
     with warn_interrupt() if checkpoint_name else nullcontext():
+        if output:
+            logger = get_server_logger(output, certs, ignore_cert_validation)
+            for event in events_gen:
+                logger.info(json.dumps(event))
+            return
+
         if format_ == TableFormat.csv:
             render.csv(DefaultAuditEvent, events_gen, columns=columns, flat=True)
         else:
@@ -154,9 +160,6 @@ def search(
                 printed = True
                 if format_ == TableFormat.json_pretty:
                     console.print_json(data=event)
-                elif output:
-                    logger = get_server_logger(output, certs, ignore_cert_validation)
-                    logger.info(json.dumps(event))
                 else:
                     click.echo(json.dumps(event))
             if not printed:

--- a/src/_cli/cmds/file_events.py
+++ b/src/_cli/cmds/file_events.py
@@ -189,6 +189,12 @@ def search(
     events = yield_all_events(query)
 
     with warn_interrupt() if checkpoint_name else nullcontext():
+        if output:
+            logger = get_server_logger(output, certs, ignore_cert_validation)
+            for event in events:
+                logger.info(json.dumps(event))
+            return
+
         if format_ == TableFormat.csv:
             render.csv(FileEventV2, events, columns=columns, flat=True)
         elif format_ == TableFormat.table:
@@ -199,9 +205,6 @@ def search(
                 printed = True
                 if format_ == TableFormat.json_pretty:
                     console.print_json(data=event)
-                elif output:
-                    logger = get_server_logger(output, certs, ignore_cert_validation)
-                    logger.info(json.dumps(event))
                 else:
                     click.echo(json.dumps(event))
             if not printed:

--- a/src/_cli/cmds/file_events.py
+++ b/src/_cli/cmds/file_events.py
@@ -32,28 +32,7 @@ from _client.queries.file_events import EventQuery
 from _client.utils import model_as_card
 from click import BadOptionUsage
 from click import File
-from rich.markdown import Markdown
 from rich.panel import Panel
-from rich.table import Table
-
-
-def render_search(search_: SavedSearch):
-    field_table = Table.grid(padding=(0, 1), expand=False)
-    field_table.title = f"Saved Search {search_.id}"
-    for name, _field in search_.__fields__.items():
-        if name == "id":
-            continue
-        if name == "notes" and search_.notes is not None:
-            field_table.add_row(
-                Panel(
-                    Markdown(search_.notes, justify="left"),
-                    title="Notes",
-                    width=80,
-                )
-            )
-        else:
-            field_table.add_row(f"{name} = {getattr(search_, name)}")
-    console.print(Panel.fit(field_table))
 
 
 @click.group(cls=IncydrGroup)

--- a/src/_cli/cmds/options/output_options.py
+++ b/src/_cli/cmds/options/output_options.py
@@ -2,7 +2,6 @@ from enum import Enum
 
 import click
 from _cli.core import incompatible_with
-from _cli.logger import ServerProtocol
 
 
 class TableFormat(str, Enum):

--- a/src/_cli/cmds/options/output_options.py
+++ b/src/_cli/cmds/options/output_options.py
@@ -55,23 +55,23 @@ columns_option = click.option(
 output_option = click.option(
     "--output",
     default=None,
-    type=ServerProtocol,
     help="Use to send the raw-json data in to a syslog server.  Pass a string in the format PROTOCOL:HOSTNAME:PORT to output "
-    "to the specified server endpoint, where format is either UDP, TCP or TLS_TCP.  Also accepts strings of the format HOSTNAME "
-    "and HOSTNAME:PORT where port will default to 514 and protocol will default to UDP.  "
-    "The --certs or --ignore-cert-validation option can be used with TLS_TCP format.",
+    "to the specified server endpoint, where format is either TCP, TLS-TCP, or UDP (ex: TCP:localhost:5000). "
+    "Also accepts strings of the format HOSTNAME and HOSTNAME:PORT. Defaults to TCP protocol on port 601. "
+    "The --certs or --ignore-cert-validation option can be used with TLS-TCP format.  Note that most data will be too large to be sent "
+    "via UDP protocol.",
     cls=incompatible_with(["format"]),
 )
 ignore_cert_validation_option = click.option(
     "--ignore-cert-validation",
     default=False,
-    help="Set to skip CA certificate validation. Incompatible with the 'certs' option.",
+    help="Set to skip CA certificate validation for the TLS-TCP protocol. Incompatible with the 'certs' option.",
     cls=incompatible_with(["certs"]),
 )
 certs_option = click.option(
     "--certs",
     default=None,
-    help="A CA certificates-chain file for the TCP-TLS protocol.",
+    help="A CA certificates-chain file for the TLS-TCP protocol.",
 )
 
 

--- a/src/_cli/logger/__init__.py
+++ b/src/_cli/logger/__init__.py
@@ -65,9 +65,9 @@ def get_server_logger(output, certs, ignore_cert_validation):
         raise BadOptionUsage(
             "output",
             "Error parsing output string.  Pass a string in the format PROTOCOL:HOSTNAME:PORT to output "
-            "to the specified server endpoint, where format is either UDP, TCP or TLS-TCP. "
+            "to the specified server endpoint, where format is either TCP, TLS-TCP, or UDP. "
             "Also accepts strings of the format HOSTNAME and HOSTNAME:PORT where port will default to 601 "
-            "and protocol will default to UDP.",
+            "and protocol will default to TCP.",
         )
 
     # certs and ignore-cert-validation only compatible with TLS-TCP

--- a/src/_cli/logger/__init__.py
+++ b/src/_cli/logger/__init__.py
@@ -6,6 +6,8 @@ from _cli.logger.enums import ServerProtocol
 from _cli.logger.handlers import NoPrioritySysLogHandler
 from click import BadOptionUsage
 
+import logging
+
 logging.raiseExceptions = False
 
 logger_deps_lock = Lock()

--- a/src/_cli/logger/__init__.py
+++ b/src/_cli/logger/__init__.py
@@ -1,5 +1,4 @@
 # prevent loggers from printing stacks to stderr if a pipe is broken
-import logging
 from threading import Lock
 
 import click
@@ -14,7 +13,7 @@ logger_deps_lock = Lock()
 
 def _init_logger(logger, handler):
     logger.setLevel(logging.INFO)
-    handler.setFormatter(logging.Formatter())
+    handler.setFormatter(logging.Formatter(fmt="%(message)s"))
     logger.addHandler(handler)
     return logger
 
@@ -24,18 +23,20 @@ def get_logger_for_server(protocol, hostname, port, certs):
 
     Args:
         hostname: The hostname of the server. It may include the port.
+        port: The port for the server.  Defaults to 601.
         protocol: The transfer protocol for sending logs.
         certs: Use for passing SSL/TLS certificates when connecting to the server.
     """
     logger = logging.getLogger("incydr_syslog")
     if len(logger.handlers):  # if logger has handlers
-        return logger.handlers
+        return logger
 
     with logger_deps_lock:
         hostname = hostname
-        port = port or 514
+        port = port or 601
+        protocol = protocol.value if isinstance(protocol, ServerProtocol) else protocol
         if not len(logger.handlers):
-            handler = NoPrioritySysLogHandler(hostname, port, protocol, certs)
+            handler = NoPrioritySysLogHandler(hostname, int(port), protocol, certs)
             handler.connect_socket()
             return _init_logger(logger, handler)
     return logger
@@ -46,8 +47,8 @@ def get_server_logger(output, certs, ignore_cert_validation):
     # parse output
     output = output.split(":")
 
-    protocol = ServerProtocol.UDP
-    port = 514
+    protocol = ServerProtocol.TCP
+    port = 601
 
     if len(output) == 1:  # HOSTNAME
         hostname = output[0]
@@ -62,21 +63,22 @@ def get_server_logger(output, certs, ignore_cert_validation):
         raise BadOptionUsage(
             "output",
             "Error parsing output string.  Pass a string in the format PROTOCOL:HOSTNAME:PORT to output "
-            "to the specified server endpoint, where format is either UDP, TCP or TLS_TCP.  Also accepts strings of the format HOSTNAME "
-            "and HOSTNAME:PORT where port will default to 514 and protocol will default to UDP.",
+            "to the specified server endpoint, where format is either UDP, TCP or TLS-TCP. "
+            "Also accepts strings of the format HOSTNAME and HOSTNAME:PORT where port will default to 601 "
+            "and protocol will default to UDP.",
         )
 
-    # certs and ignore-cert-validation only compatible with TLS_TCP
+    # certs and ignore-cert-validation only compatible with TLS-TCP
     if protocol != ServerProtocol.TLS_TCP:
         arg = None
         if ignore_cert_validation:
-            arg = ("ignore-cert-validation",)
+            arg = "ignore-cert-validation"
         elif certs is not None:
             arg = "certs"
         if arg is not None:
             raise click.BadOptionUsage(
                 arg,
-                f"'{arg}' can only be used with '--protocol {ServerProtocol.TLS_TCP}'.",
+                f"'{arg}' can only be used with '{ServerProtocol.TLS_TCP}' protocol.",
             )
 
     if ignore_cert_validation:

--- a/src/_cli/logger/handlers.py
+++ b/src/_cli/logger/handlers.py
@@ -1,10 +1,11 @@
 import socket
 import ssl
 import sys
-import logging
-from logging.handlers import SysLogHandler
+
 from _cli.logger import ServerProtocol
 
+import logging
+from logging.handlers import SysLogHandler
 
 
 class SyslogServerNetworkConnectionError(Exception):

--- a/src/_cli/logger/handlers.py
+++ b/src/_cli/logger/handlers.py
@@ -1,10 +1,10 @@
-import logging
 import socket
 import ssl
 import sys
+import logging
 from logging.handlers import SysLogHandler
-
 from _cli.logger import ServerProtocol
+
 
 
 class SyslogServerNetworkConnectionError(Exception):
@@ -129,7 +129,7 @@ def _try_get_socket_type_from_protocol(protocol):
     if socket_type is None:
         raise ValueError(
             "Could not determine socket type. "
-            f"Expected one of {list(ServerProtocol())}, but got {protocol}."
+            f"Expected one of {list(ServerProtocol)}, but got {protocol}."
         )
     return socket_type
 

--- a/src/_client/core/client.py
+++ b/src/_client/core/client.py
@@ -25,6 +25,8 @@ from requests_toolbelt import user_agent
 from requests_toolbelt.sessions import BaseUrlSession
 from requests_toolbelt.utils.dump import dump_response
 
+import logging
+
 _base_user_agent = user_agent("incydr", __version__)
 _auth_header_regex = re.compile(r"Authorization: (Bearer|Basic) \S+")
 

--- a/src/_client/core/client.py
+++ b/src/_client/core/client.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import logging
 import re
 import traceback
 from collections import deque

--- a/src/_client/core/settings.py
+++ b/src/_client/core/settings.py
@@ -3,7 +3,6 @@ import warnings
 from io import IOBase
 from pathlib import Path
 from typing import Union
-import logging
 
 from _client.enums import _Enum
 from pydantic import BaseSettings
@@ -14,6 +13,8 @@ from pydantic import validator
 from rich import pretty
 from rich.console import Console
 from rich.logging import RichHandler
+
+import logging
 
 # capture default displayhook so we can "uninstall" rich
 _sys_displayhook = sys.displayhook

--- a/src/_client/core/settings.py
+++ b/src/_client/core/settings.py
@@ -1,9 +1,9 @@
-import logging
 import sys
 import warnings
 from io import IOBase
 from pathlib import Path
 from typing import Union
+import logging
 
 from _client.enums import _Enum
 from pydantic import BaseSettings

--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+import logging
+
+
+@pytest.fixture()
+def mock_log_record(mocker):
+    mock_record = mocker.MagicMock(spec=logging.LogRecord)
+    mock_record.msg = "test"
+    mock_record.exc_info = None
+    mock_record.exc_text = None
+    mock_record.stack_info = None
+    return mock_record

--- a/tests/logging/test_handlers.py
+++ b/tests/logging/test_handlers.py
@@ -1,0 +1,253 @@
+import ssl
+from socket import IPPROTO_TCP
+from socket import IPPROTO_UDP
+from socket import SOCK_DGRAM
+from socket import SOCK_STREAM
+from socket import socket
+from socket import SocketKind
+
+import pytest
+
+import logging
+from incydr.cli.logger.enums import ServerProtocol
+from incydr.cli.logger.handlers import NoPrioritySysLogHandler
+from incydr.cli.logger.handlers import SyslogServerNetworkConnectionError
+
+_TEST_HOST = "example.com"
+_TEST_PORT = 5000
+_TEST_CERTS = "path/to/cert.crt"
+tls_and_tcp_test = pytest.mark.parametrize(
+    "protocol", (ServerProtocol.TLS_TCP, ServerProtocol.TCP)
+)
+tcp_and_udp_test = pytest.mark.parametrize(
+    "protocol", (ServerProtocol.TCP, ServerProtocol.UDP)
+)
+
+
+class SocketMocks:
+    mock_socket = None
+    socket_initializer = None
+
+    class SSLMocks:
+        mock_ssl_context = None
+        context_creator = None
+
+
+@pytest.fixture(autouse=True)
+def socket_mocks(mocker):
+    mocks = SocketMocks()
+    new_socket = mocker.MagicMock(spec=ssl.SSLSocket)
+    mocks.mock_socket = new_socket
+    mocks.socket_initializer = _get_normal_socket_initializer_mocks(mocker, new_socket)
+    mocks.SSLMocks.mock_ssl_context = mocker.MagicMock(ssl.SSLContext)
+    mocks.SSLMocks.mock_ssl_context.wrap_socket.return_value = new_socket
+    mocks.SSLMocks.context_creator = mocker.patch(
+        "incydr.cli.logger.handlers.ssl.create_default_context"
+    )
+    mocks.SSLMocks.context_creator.return_value = mocks.SSLMocks.mock_ssl_context
+    return mocks
+
+
+@pytest.fixture()
+def system_exception_info(mocker):
+    return mocker.patch("incydr.cli.logger.handlers.sys.exc_info")
+
+
+@pytest.fixture()
+def broken_pipe_error(system_exception_info):
+    system_exception_info.return_value = (BrokenPipeError, None, None)
+    return system_exception_info
+
+
+@pytest.fixture()
+def connection_reset_error(system_exception_info):
+    system_exception_info.return_value = (ConnectionResetError, None, None)
+    return system_exception_info
+
+
+def _get_normal_socket_initializer_mocks(mocker, new_socket):
+    new_socket_magic_method = mocker.patch(
+        "incydr.cli.logger.handlers.socket.socket.__new__"
+    )
+    new_socket_magic_method.return_value = new_socket
+    return new_socket_magic_method
+
+
+class TestNoPrioritySysLogHandler:
+    def test_init_sets_expected_address(self):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        assert handler.address == (_TEST_HOST, _TEST_PORT)
+
+    @tls_and_tcp_test
+    def test_init_when_stream_based_sets_expected_sock_type(self, protocol):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        actual = handler.socktype
+        assert actual == SocketKind.SOCK_STREAM
+
+    def test_init_when_udp_sets_expected_sock_type(self):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        actual = handler.socktype
+        assert actual == SocketKind.SOCK_DGRAM
+
+    def test_init_sets_socket_to_none(self):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        assert handler.socket is None
+
+    @tcp_and_udp_test
+    def test_init_when_not_tls_sets_wrap_socket_to_false(self, protocol):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        assert not handler._wrap_socket
+
+    def test_init_when_using_tls_sets_wrap_socket_to_true(self):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.TLS_TCP, _TEST_CERTS
+        )
+        assert handler._wrap_socket
+        assert handler._certs == _TEST_CERTS
+
+    def test_connect_socket_only_connects_once(self, socket_mocks):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        handler.connect_socket()
+        handler.connect_socket()
+        assert socket_mocks.socket_initializer.call_count == 1
+
+    def test_connect_socket_when_udp_initializes_with_expected_properties(
+        self, socket_mocks
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        handler.connect_socket()
+        call_args = socket_mocks.socket_initializer.call_args[0]
+        assert call_args[0] == socket
+        assert call_args[2] == SOCK_DGRAM
+        assert call_args[3] == IPPROTO_UDP
+
+    @tls_and_tcp_test
+    def test_connect_socket_when_tcp_initializes_with_expected_properties(
+        self, socket_mocks, protocol
+    ):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        handler.connect_socket()
+        call_args = socket_mocks.socket_initializer.call_args[0]
+        assert call_args[0] == socket
+        assert call_args[2] == SOCK_STREAM
+        assert call_args[3] == IPPROTO_TCP
+        assert socket_mocks.mock_socket.connect.call_count == 1
+
+    def test_connect_when_tls_calls_create_default_context(self, socket_mocks):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.TLS_TCP, "certs"
+        )
+        handler.connect_socket()
+        call_args = socket_mocks.SSLMocks.context_creator.call_args
+        assert call_args[1]["cafile"] == "certs"
+
+    @pytest.mark.parametrize("ignore", ("ignore", "IGNORE"))
+    def test_connect_when_tls_and_told_to_ignore_certs_sets_expected_context_properties(
+        self, socket_mocks, ignore
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.TLS_TCP, ignore
+        )
+        handler.connect_socket()
+        assert socket_mocks.SSLMocks.mock_ssl_context.verify_mode == ssl.CERT_NONE
+        assert not socket_mocks.SSLMocks.mock_ssl_context.check_hostname
+
+    @pytest.mark.parametrize("ignore", ("ignore", "IGNORE"))
+    def test_connect_when_tls_and_told_to_ignore_certs_creates_context_with_none_certs(
+        self, socket_mocks, ignore
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.TLS_TCP, ignore
+        )
+        handler.connect_socket()
+        socket_mocks.SSLMocks.context_creator.assert_called_once_with(cafile=None)
+
+    @tls_and_tcp_test
+    def test_connect_socket_when_tcp_or_tls_sets_timeout_for_connection_and_resets(
+        self, socket_mocks, protocol
+    ):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        handler.connect_socket()
+        call_args = socket_mocks.mock_socket.settimeout.call_args_list
+        assert len(call_args) == 2
+        assert call_args[0][0][0] == 10
+        assert call_args[1][0][0] is None
+
+    @tls_and_tcp_test
+    def test_emit_when_tcp_calls_socket_sendall_with_expected_message(
+        self, mock_log_record, protocol
+    ):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        handler.connect_socket()
+        formatter = logging.Formatter(fmt="%(message)s")
+        handler.setFormatter(formatter)
+        handler.emit(mock_log_record)
+        expected_message = (formatter.format(mock_log_record) + "\n").encode("utf-8")
+        handler.socket.sendall.assert_called_once_with(expected_message)
+
+    def test_emit_when_udp_calls_socket_sendto_with_expected_message_and_address(
+        self, mock_log_record
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        handler.connect_socket()
+        formatter = logging.Formatter(fmt="%(message)s")
+        handler.setFormatter(formatter)
+        handler.emit(mock_log_record)
+        expected_message = (formatter.format(mock_log_record) + "\n").encode("utf-8")
+        handler.socket.sendto.assert_called_once_with(
+            expected_message, (_TEST_HOST, _TEST_PORT)
+        )
+
+    def test_handle_error_when_broken_pipe_error_occurs_raises_expected_error(
+        self, mock_log_record, broken_pipe_error
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        with pytest.raises(SyslogServerNetworkConnectionError):
+            handler.handleError(mock_log_record)
+
+    def test_handle_error_when_connection_reset_error_occurs_raises_expected_error(
+        self, mock_log_record, connection_reset_error
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        with pytest.raises(SyslogServerNetworkConnectionError):
+            handler.handleError(mock_log_record)
+
+    def test_close_when_using_tls_unwraps_socket(self):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.TLS_TCP, None
+        )
+        handler.connect_socket()
+        handler.close()
+        assert handler.socket.unwrap.call_count == 1
+
+    @tcp_and_udp_test
+    def test_close_when_not_using_tls_does_not_unwrap_socket(self, protocol):
+        handler = NoPrioritySysLogHandler(_TEST_HOST, _TEST_PORT, protocol, None)
+        handler.connect_socket()
+        handler.close()
+        assert not handler.socket.unwrap.call_count
+
+    def test_close_globally_closes(self, mocker):
+        global_close = mocker.patch("incydr.cli.logger.handlers.logging.Handler.close")
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        handler.connect_socket()
+        handler.close()
+        assert global_close.call_count == 1

--- a/tests/logging/test_handlers.py
+++ b/tests/logging/test_handlers.py
@@ -7,11 +7,11 @@ from socket import socket
 from socket import SocketKind
 
 import pytest
+from _cli.logger.enums import ServerProtocol
+from _cli.logger.handlers import NoPrioritySysLogHandler
+from _cli.logger.handlers import SyslogServerNetworkConnectionError
 
 import logging
-from incydr.cli.logger.enums import ServerProtocol
-from incydr.cli.logger.handlers import NoPrioritySysLogHandler
-from incydr.cli.logger.handlers import SyslogServerNetworkConnectionError
 
 _TEST_HOST = "example.com"
 _TEST_PORT = 5000
@@ -42,7 +42,7 @@ def socket_mocks(mocker):
     mocks.SSLMocks.mock_ssl_context = mocker.MagicMock(ssl.SSLContext)
     mocks.SSLMocks.mock_ssl_context.wrap_socket.return_value = new_socket
     mocks.SSLMocks.context_creator = mocker.patch(
-        "incydr.cli.logger.handlers.ssl.create_default_context"
+        "_cli.logger.handlers.ssl.create_default_context"
     )
     mocks.SSLMocks.context_creator.return_value = mocks.SSLMocks.mock_ssl_context
     return mocks
@@ -50,7 +50,7 @@ def socket_mocks(mocker):
 
 @pytest.fixture()
 def system_exception_info(mocker):
-    return mocker.patch("incydr.cli.logger.handlers.sys.exc_info")
+    return mocker.patch("_cli.logger.handlers.sys.exc_info")
 
 
 @pytest.fixture()
@@ -66,9 +66,7 @@ def connection_reset_error(system_exception_info):
 
 
 def _get_normal_socket_initializer_mocks(mocker, new_socket):
-    new_socket_magic_method = mocker.patch(
-        "incydr.cli.logger.handlers.socket.socket.__new__"
-    )
+    new_socket_magic_method = mocker.patch("_cli.logger.handlers.socket.socket.__new__")
     new_socket_magic_method.return_value = new_socket
     return new_socket_magic_method
 
@@ -244,7 +242,7 @@ class TestNoPrioritySysLogHandler:
         assert not handler.socket.unwrap.call_count
 
     def test_close_globally_closes(self, mocker):
-        global_close = mocker.patch("incydr.cli.logger.handlers.logging.Handler.close")
+        global_close = mocker.patch("_cli.logger.handlers.logging.Handler.close")
         handler = NoPrioritySysLogHandler(
             _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
         )

--- a/tests/logging/test_init.py
+++ b/tests/logging/test_init.py
@@ -1,15 +1,15 @@
 import pytest
+from _cli.logger import _init_logger
+from _cli.logger import get_logger_for_server
+from _cli.logger.enums import ServerProtocol
+from _cli.logger.handlers import NoPrioritySysLogHandler
 
 import logging
-from incydr.cli.logger import _init_logger
-from incydr.cli.logger import get_logger_for_server
-from incydr.cli.logger.enums import ServerProtocol
-from incydr.cli.logger.handlers import NoPrioritySysLogHandler
 
 
 @pytest.fixture(autouse=True)
 def init_socket_mock(mocker):
-    return mocker.patch("incydr.cli.logger.NoPrioritySysLogHandler.connect_socket")
+    return mocker.patch("_cli.logger.NoPrioritySysLogHandler.connect_socket")
 
 
 @pytest.fixture(autouse=True)
@@ -52,7 +52,7 @@ def test_get_logger_for_server_constructs_handler_with_expected_args(
     mocker, monkeypatch
 ):
     no_priority_syslog_handler = mocker.patch(
-        "incydr.cli.logger.handlers.NoPrioritySysLogHandler.__init__"
+        "_cli.logger.handlers.NoPrioritySysLogHandler.__init__"
     )
     no_priority_syslog_handler.return_value = None
     get_logger_for_server(ServerProtocol.TCP, "example.com", None, "cert")
@@ -65,7 +65,7 @@ def test_get_logger_for_server_when_hostname_includes_port_constructs_handler_wi
     mocker,
 ):
     no_priority_syslog_handler = mocker.patch(
-        "incydr.cli.logger.handlers.NoPrioritySysLogHandler.__init__"
+        "_cli.logger.handlers.NoPrioritySysLogHandler.__init__"
     )
     no_priority_syslog_handler.return_value = None
     get_logger_for_server(ServerProtocol.TCP, "example.com", 999, None)

--- a/tests/logging/test_init.py
+++ b/tests/logging/test_init.py
@@ -1,0 +1,82 @@
+import pytest
+
+import logging
+from incydr.cli.logger import _init_logger
+from incydr.cli.logger import get_logger_for_server
+from incydr.cli.logger.enums import ServerProtocol
+from incydr.cli.logger.handlers import NoPrioritySysLogHandler
+
+
+@pytest.fixture(autouse=True)
+def init_socket_mock(mocker):
+    return mocker.patch("incydr.cli.logger.NoPrioritySysLogHandler.connect_socket")
+
+
+@pytest.fixture(autouse=True)
+def fresh_syslog_handler(init_socket_mock):
+    # Set handlers to empty list so it gets initialized each test
+    get_logger_for_server(
+        ServerProtocol.TCP,
+        "example.com",
+        None,
+        None,
+    ).handlers = []
+    init_socket_mock.call_count = 0
+
+
+def test_init_logger_does_as_expected():
+    logger = logging.getLogger("TEST_INCYDR_CLI")
+    handler = logging.Handler()
+    _init_logger(logger, handler)
+    assert handler in logger.handlers
+    assert isinstance(handler.formatter, logging.Formatter)
+
+
+def test_get_logger_for_server_has_info_level():
+    logger = get_logger_for_server(ServerProtocol.TCP, "example.com", None, None)
+    assert logger.level == logging.INFO
+
+
+def test_get_logger_for_server_when_called_twice_only_has_one_handler():
+    get_logger_for_server(ServerProtocol.TCP, "example.com", None, None)
+    logger = get_logger_for_server(ServerProtocol.TCP, "example.com", None, None)
+    assert len(logger.handlers) == 1
+
+
+def test_get_logger_for_server_uses_no_priority_syslog_handler():
+    logger = get_logger_for_server(ServerProtocol.TCP, "example.com", None, None)
+    assert type(logger.handlers[0]) == NoPrioritySysLogHandler
+
+
+def test_get_logger_for_server_constructs_handler_with_expected_args(
+    mocker, monkeypatch
+):
+    no_priority_syslog_handler = mocker.patch(
+        "incydr.cli.logger.handlers.NoPrioritySysLogHandler.__init__"
+    )
+    no_priority_syslog_handler.return_value = None
+    get_logger_for_server(ServerProtocol.TCP, "example.com", None, "cert")
+    no_priority_syslog_handler.assert_called_once_with(
+        "example.com", 601, ServerProtocol.TCP.value, "cert"
+    )
+
+
+def test_get_logger_for_server_when_hostname_includes_port_constructs_handler_with_expected_args(
+    mocker,
+):
+    no_priority_syslog_handler = mocker.patch(
+        "incydr.cli.logger.handlers.NoPrioritySysLogHandler.__init__"
+    )
+    no_priority_syslog_handler.return_value = None
+    get_logger_for_server(ServerProtocol.TCP, "example.com", 999, None)
+    no_priority_syslog_handler.assert_called_once_with(
+        "example.com",
+        999,
+        ServerProtocol.TCP.value,
+        None,
+    )
+
+
+def test_get_logger_for_server_inits_socket(init_socket_mock):
+    get_logger_for_server(ServerProtocol.TCP, "example.com", None, None)
+    assert init_socket_mock.call_count == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,11 +1,12 @@
 import re
 import sys
-import logging
 
 import pytest
 from incydr import Client
 from pytest_httpserver import HTTPServer
 from rich.logging import RichHandler
+
+import logging
 
 
 class TestLogLevels:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,6 @@
-import logging
 import re
 import sys
+import logging
 
 import pytest
 from incydr import Client


### PR DESCRIPTION
Syslogging implementation.  Includes the following changes

- when outputting alerts, events, or audit-log events, the logger is only _init_ once
- `output` option now accepts a string 
- ensure `port` is passed as an integer and `protocol` is the corresponding value str when connected the logger
- adds logger and handler test files