### PR TITLE
update date parsing with dateutil.parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "rich",
   "pydantic[dotenv]",
   "isodate",
+  "python-dateutil",
 ]
 dynamic = ["version"]
 
@@ -83,6 +84,7 @@ dependencies = [
   "pytest-lazy-fixture",
   "click",
   "chardet",
+  "python-dateutil",
 ]
 [tool.hatch.envs.test.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=incydr"

--- a/src/_cli/cmds/user_risk_profiles.py
+++ b/src/_cli/cmds/user_risk_profiles.py
@@ -22,7 +22,7 @@ from _cli.core import incompatible_with
 from _cli.core import IncydrCommand
 from _cli.core import IncydrGroup
 from _client.core.client import Client
-from _client.user_risk_profiles.client import DateParseError
+from _client.exceptions import DateParseError
 from _client.user_risk_profiles.models import UserRiskProfile
 from _client.utils import model_as_card
 from pydantic import Field

--- a/src/_client/exceptions.py
+++ b/src/_client/exceptions.py
@@ -53,3 +53,16 @@ class WatchlistNotFoundError(IncydrException):
         self.name = name
         self.message = f"Watchlist Not Found Error: No watchlist matching the type or title '{name}' was found."
         super().__init__(self.message)
+
+
+class DateParseError(IncydrException):
+    """An error raised when the date data cannot be parsed."""
+
+    def __init__(self, date, msg=None):
+        self._date = date
+        message = msg or f"DateParseError: Error parsing time data: '{date}'."
+        super().__init__(message)
+
+    @property
+    def date(self):
+        return self._date

--- a/src/_client/user_risk_profiles/client.py
+++ b/src/_client/user_risk_profiles/client.py
@@ -3,7 +3,7 @@ from itertools import count
 from typing import Iterator
 from typing import Union
 
-from _client.exceptions import IncydrException
+from _client.exceptions import DateParseError
 from _client.queries.utils import DATE_STR_FORMAT
 from _client.user_risk_profiles.models import Date
 from _client.user_risk_profiles.models import QueryUserRiskProfilesRequest
@@ -11,15 +11,6 @@ from _client.user_risk_profiles.models import UpdateUserRiskProfileRequest
 from _client.user_risk_profiles.models import UserRiskProfile
 from _client.user_risk_profiles.models import UserRiskProfilesPage
 from requests import Response
-
-
-class DateParseError(IncydrException):
-    """An error raised when the date data cannot be parsed."""
-
-    def __init__(self, date):
-        super().__init__(
-            f"Date Parse Error: Error parsing time data. Date '{date}' does not match format {DATE_STR_FORMAT}."
-        )
 
 
 class UserRiskProfiles:
@@ -252,5 +243,8 @@ def _create_date(date: Union[datetime, str]):
         try:
             date = datetime.strptime(date, DATE_STR_FORMAT)
         except ValueError:
-            raise DateParseError(date)
+            raise DateParseError(
+                date,
+                msg=f"DateParseError: Error parsing time data. Date '{date}' does not match format {DATE_STR_FORMAT}.",
+            )
     return Date(day=date.day, month=date.month, year=date.year)

--- a/tests/test_user_risk_profiles.py
+++ b/tests/test_user_risk_profiles.py
@@ -302,7 +302,7 @@ def test_cli_update_when_incorrect_date_format_raises_date_parse_exception(
         ["users", "risk-profiles", "update", TEST_USER_ID, date_option, date_input],
     )
     assert result.exit_code == 1
-    assert "Date Parse Error: Error parsing time data." in result.output
+    assert "DateParseError: Error parsing time data." in result.output
 
 
 def test_cli_update_when_no_options_raises_usage_error(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
+import datetime
 from typing import Optional
 
 import pytest
+from _client.queries.utils import parse_str_to_dt
 from _client.utils import flatten_fields
 from _client.utils import get_field_value_and_info
 from _client.utils import get_fields
@@ -200,3 +202,27 @@ def test_get_field_value_and_info():
     )
     assert grandchild_value is None
     assert "table" in grandchild_field.field_info.extra
+
+
+@pytest.mark.parametrize(
+    "ts_str,expected",
+    [
+        ("2022-01-02", datetime.datetime(2022, 1, 2, tzinfo=datetime.timezone.utc)),
+        (
+            "2022-02-01 10:30:50",
+            datetime.datetime(2022, 2, 1, 10, 30, 50, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2022-02-01T10:30:50Z",
+            datetime.datetime(2022, 2, 1, 10, 30, 50, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2022-02-01T10:30:50.12345Z",
+            datetime.datetime(
+                2022, 2, 1, 10, 30, 50, 123450, tzinfo=datetime.timezone.utc
+            ),
+        ),
+    ],
+)
+def test_parse_str_to_dt(ts_str, expected):
+    assert parse_str_to_dt(ts_str) == expected


### PR DESCRIPTION
Bobby had run into issues certain audit log events had timestamps in a slightly different format.  Updates our `date_str_to_ts()` method to use the `dateutil.parser.parse()` method ([docs here](http://niemeyer.net/python-dateutil#head-a23e8ae0a661d77b89dfb3476f85b26f0b30349c)) to make that method more flexible.