### PR TITLE
restructure integration guides

### DIFF
--- a/docs/integration-guides/index.md
+++ b/docs/integration-guides/index.md
@@ -1,0 +1,3 @@
+# Integration Guides
+
+Here you'll find guides to integrating Code42 with various 3rd party platforms.

--- a/docs/integration-guides/sentinel/azure-sentinel-data-collector.md
+++ b/docs/integration-guides/sentinel/azure-sentinel-data-collector.md
@@ -1,4 +1,4 @@
-### Prepare your environment:
+### Prepare your environment
 
 - [Install py42 into your Python environment](https://py42docs.code42.com/en/stable/userguides/gettingstarted.html#installation)
 - [Create a Code42 API Client](https://support.code42.com/Incydr/Admin/Code42_console_reference/API_clients) to authenticate py42. The `Alerts Read` permission is required to query alerts.
@@ -9,7 +9,7 @@
 <b>NOTE:</b> Workspace ID and Keys can be found in your Log Analytics Workspace Settings under <b>Agents Management</b> > <b>Log Analytics agent instructions</b>.
 </aside>
 
-### Writing the script:
+### Writing the script
 
 First, import the py42 SDK client and required classes for building your Alert query:
 

--- a/docs/integration-guides/sentinel/azure-sentinel-log-analytics.md
+++ b/docs/integration-guides/sentinel/azure-sentinel-log-analytics.md
@@ -1,5 +1,5 @@
 
-### Prepare your environment:
+### Prepare your environment
 
 - Install the [Azure Log Analytics Agent](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/log-analytics-agent)
 - Install the [Code42 CLI](https://clidocs.code42.com/en/stable/userguides/gettingstarted.html)

--- a/docs/integration-guides/sentinel/introduction.md
+++ b/docs/integration-guides/sentinel/introduction.md
@@ -1,0 +1,10 @@
+Microsoft Sentinel can accept arbitrary json data as Custom Log sources, so you can ingest almost any type of Incydr
+data for querying within Sentinel, including Alerts, File Events, and Audit Log events.
+
+Sentinel has two methods of ingesting JSON data as Custom Log sources: the data collector HTTP API, and the Log
+Analytics Linux agent. While the examples below will focus on Incydr Alerts, the patterns can be re-used for almost any
+type of data you can pull from the Code42 API or CLI.
+
+[Data collector API](azure-sentinel-data-collector.md)
+
+[Log Analytics Agent](azure-sentinel-log-analytics.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
         - navigation.instant
         - navigation.tracking
         - content.code.annotate
+        - navigation.indexes
     palette:
     - scheme: default
 #    # Palette toggle for light mode
@@ -78,9 +79,11 @@ nav:
         - Trusted Activites: 'cli/cmds/trusted_activities.md'
         - Watchlists: 'cli/cmds/watchlists.md'
   - Guides:
-    - Microsoft Sentinel:
-      - Data Collector API: 'guides/azure-sentinel-data-collector.md'
-      - Log Analytics Agent: 'guides/azure-sentinel-log-analytics.md'
+      - Introduction: 'integration-guides/index.md'
+      - Microsoft Sentinel:
+        - 'integration-guides/sentinel/introduction.md'
+        - Data Collector API: 'integration-guides/sentinel/azure-sentinel-data-collector.md'
+        - Log Analytics Agent: 'integration-guides/sentinel/azure-sentinel-log-analytics.md'
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
we'll still need to update the guides to incydr sdk themselves, but this fixes the url to match the old portal and adds a tiny bit of structural improvements. 