### PR TITLE
wait to call Redoc.init until page is fully loaded

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,5 +37,7 @@ hide:
             }
         }
     };
-    Redoc.init("https://raw.githubusercontent.com/code42/developer.code42.com/gh-pages/api/code42api.json", opts, document.getElementById("redoc-container"))
+    window.addEventListener('load', function () {
+        Redoc.init("https://raw.githubusercontent.com/code42/developer.code42.com/gh-pages/api/code42api.json", opts, document.getElementById("redoc-container"))
+    })
 </script>


### PR DESCRIPTION
Going directly to the API reference page causes the Redoc.init() to be called before the redoc.standalone.js script is loaded.

This has it wait for the full page to load to trigger.