### PR TITLE
hide API Reference header

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,7 @@ hide:
   - navigation
   - toc
 ---
+#
 <script>
     var opts = {
         scrollYOffset: 120,


### PR DESCRIPTION
It looks like an update to mkdocs-material caused the API Reference header to get added to the page, and it pokes through the API docs. 

An empty markdown header overrides that.