### PR TITLE
add https to url

### DIFF
--- a/docs/cli/getting_started.md
+++ b/docs/cli/getting_started.md
@@ -23,7 +23,7 @@ The following values should be present in one of the above locations:
 ```bash
 INCYDR_API_CLIENT_ID='api-client-key'
 INCYDR_API_CLIENT_SECRET='api-client-secret'
-INCYDR_URL='code42.api.url'
+INCYDR_URL='https://code42.api.url'
 ```
 
 See [Incydr SDK Settings](../sdk/settings.md) for more available settings.


### PR DESCRIPTION
The CLI will fail if the provided INCYDR_URL does not include the `https://` bit. We should add it to the getting started guide so this is more clear to admins.