### PR TITLE
Clarify the API URLs to use in SDK, CLI calls

### DIFF
--- a/docs/cli/getting_started.md
+++ b/docs/cli/getting_started.md
@@ -23,8 +23,18 @@ The following values should be present in one of the above locations:
 ```bash
 INCYDR_API_CLIENT_ID='api-client-key'
 INCYDR_API_CLIENT_SECRET='api-client-secret'
-INCYDR_URL='https://code42.api.url'
+INCYDR_URL='https://example.com'
 ```
+
+You must update the `INCYDR_URL` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
+
+| Console Domain         | API Domain         |
+| ---------------------- | ------------------ |
+| console.us.code42.com  | api.us.code42.com  |
+| console.us2.code42.com | api.us2.code42.com |
+| console.ie.code42.com  | api.ie.code42.com  |
+| console.gov.code42.com | api.gov.code42.com |
+
 
 See [Incydr SDK Settings](../sdk/settings.md) for more available settings.
 

--- a/docs/cli/getting_started.md
+++ b/docs/cli/getting_started.md
@@ -23,10 +23,10 @@ The following values should be present in one of the above locations:
 ```bash
 INCYDR_API_CLIENT_ID='api-client-key'
 INCYDR_API_CLIENT_SECRET='api-client-secret'
-INCYDR_URL='https://example.com'
+INCYDR_URL='api_domain'
 ```
 
-You must update the `INCYDR_URL` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
+You must update the `api_domain` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
 
 | Console Domain         | API Domain         |
 | ---------------------- | ------------------ |

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -21,11 +21,20 @@ Import the `incydr.Client` initialize with your Incydr API Client:
 import incydr
 
 client = incydr.Client(
-    url="https://api.us.code42.com",
+    url="https://example.com",
     api_client_id="my_id",
     api_client_secret="my_secret" # (1)
 )
 ```
+
+You must update the `url` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
+
+| Console Domain         | API Domain         |
+| ---------------------- | ------------------ |
+| console.us.code42.com  | api.us.code42.com  |
+| console.us2.code42.com | api.us2.code42.com |
+| console.ie.code42.com  | api.ie.code42.com  |
+| console.gov.code42.com | api.gov.code42.com |
 
 Any arguments that are not provided to the `incydr.Client` will attempt to be loaded from environment variables or
    .env files. See [Settings](/sdk/settings) for more details

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -21,13 +21,13 @@ Import the `incydr.Client` initialize with your Incydr API Client:
 import incydr
 
 client = incydr.Client(
-    url="https://example.com",
+    url="api_domain",
     api_client_id="my_id",
     api_client_secret="my_secret" # (1)
 )
 ```
 
-You must update the `url` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
+You must update the `api_domain` value for your specific environment. To find the correct value, identify the URL you use to sign in to the Code42 web console, then note the corresponding **API Domain** value in the table below. Use https for all API requests.
 
 | Console Domain         | API Domain         |
 | ---------------------- | ------------------ |

--- a/src/_incydr_sdk/core/client.py
+++ b/src/_incydr_sdk/core/client.py
@@ -43,7 +43,7 @@ class Client:
     Usage example:
 
         >>> import incydr
-        >>> client = incydr.Client(url="https://api.us.code42.com", api_client_id="<client_id>", api_client_secret="<client_secret>")
+        >>> client = incydr.Client(url="https://example.com", api_client_id="<client_id>", api_client_secret="<client_secret>")
 
     """
 

--- a/src/_incydr_sdk/core/client.py
+++ b/src/_incydr_sdk/core/client.py
@@ -43,7 +43,7 @@ class Client:
     Usage example:
 
         >>> import incydr
-        >>> client = incydr.Client(url="https://example.com", api_client_id="<client_id>", api_client_secret="<client_secret>")
+        >>> client = incydr.Client(url="<api_domain>", api_client_id="<client_id>", api_client_secret="<client_secret>")
 
     """
 


### PR DESCRIPTION
Overview of changes captured in 14802. Summary:

- Updated CLI getting started page to explicitly call out the API URLs that integrators need to use  (https://developer.code42.com/cli/getting_started/)
- Updated SDK introduction page to explicitly call out the API URLs that integrators need to use (https://developer.code42.com/sdk/)
- Updated comment block at top of client.py to have "example.com" in the usage example that populates the dev portal