### PR TITLE
prep version 2.2.1 and remove support for end-of-life python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@
  how a consumer would use the library or CLI tool (e.g. adding unit tests, updating documentation, etc) are not captured
  here.
 
-## Unreleased
+## 2.2.1 - 2024-12-18
+
+### Added
+
+- Added support for pyton 3.13.
 
 ### Updated
 
 - The CLI and SDK now have user-agent headers consistent with Code42 current standards.
+
+### Removed
+
+- Removed support for python 3.7 and 3.8, which are end-of-life.
 
 
 ## 2.2.0 - 2024-11-18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "incydr"
 description = "Code42's Incydr Python SDK"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [
@@ -15,12 +15,11 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/_incydr_sdk/__version__.py
+++ b/src/_incydr_sdk/__version__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Code42 Software <integrations@code42.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
python 3.7 and 3.8 are end-of-life, see https://devguide.python.org/versions/