### PR TITLE
update sessions contentinspection schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
  how a consumer would use the library or CLI tool (e.g. adding unit tests, updating documentation, etc) are not captured
  here.
 
-## Unreleased
+## 2.3.1 - 2025-05-13
+
+### Fixed
+
+- An issue where Sessions validation would fail due to an updated content inspection schema.
 
 ### Updated
 

--- a/src/_incydr_sdk/__version__.py
+++ b/src/_incydr_sdk/__version__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Code42 Software <integrations@code42.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/src/_incydr_sdk/sessions/models/models.py
+++ b/src/_incydr_sdk/sessions/models/models.py
@@ -18,11 +18,10 @@ class ContentInspectionEvent(Model):
 
 
 class ContentInspectionResult(Model):
-    event_results: List[ContentInspectionEvent] = Field(
-        alias="eventResults",
-        description="List of all content inspection events that have occurred.",
+    detected_on_alerts: List[str] = Field(
+        alias="detectedOnAlerts",
+        description="A list of content categories or types found on events which triggered alerts."
     )
-    status: Optional[str]
 
 
 class Note(Model):

--- a/src/_incydr_sdk/sessions/models/models.py
+++ b/src/_incydr_sdk/sessions/models/models.py
@@ -20,7 +20,7 @@ class ContentInspectionEvent(Model):
 class ContentInspectionResult(Model):
     detected_on_alerts: List[str] = Field(
         alias="detectedOnAlerts",
-        description="A list of content categories or types found on events which triggered alerts."
+        description="A list of content categories or types found on events which triggered alerts.",
     )
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -32,10 +32,9 @@ TEST_SESSION = {
     "actorId": TEST_SESSION_ID,
     "beginTime": POSIX_TS,
     "contentInspectionResults": {
-        "eventResults": [
-            {"eventId": "event-id", "piiType": ["string"], "status": "PENDING"}
-        ],
-        "status": "PENDING",
+        "detectedOnAlerts": [
+            "PII"
+        ]
     },
     "contextSummary": "string",
     "criticalEvents": 0,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -31,11 +31,7 @@ END_TIMESTAMP = 1734652800000  # in ms
 TEST_SESSION = {
     "actorId": TEST_SESSION_ID,
     "beginTime": POSIX_TS,
-    "contentInspectionResults": {
-        "detectedOnAlerts": [
-            "PII"
-        ]
-    },
+    "contentInspectionResults": {"detectedOnAlerts": ["PII"]},
     "contextSummary": "string",
     "criticalEvents": 0,
     "endTime": POSIX_TS,


### PR DESCRIPTION
The ContentInspectionResult schema has changed, we need to update in order to allow Sessions validation to function correctly.