### PR TITLE
INTEG-3207 - support actorName and ruleName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
  how a consumer would use the library or CLI tool (e.g. adding unit tests, updating documentation, etc) are not captured
  here.
 
-## Unreleased
+## 2.12.2 - 2026-06-22
 
 ### Added
 - Support for the `actorName` and `ruleName` fields on the Session response object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
  how a consumer would use the library or CLI tool (e.g. adding unit tests, updating documentation, etc) are not captured
  here.
 
+## Unreleased
+
+### Added
+- Support for the `actorName` and `ruleName` fields on the Session response object.
+
 ## 2.12.1 - 2026-06-05
 
 ### Fixed

--- a/src/_incydr_cli/cmds/sessions.py
+++ b/src/_incydr_cli/cmds/sessions.py
@@ -196,6 +196,7 @@ def search(
                 "context_summary",
                 "exfiltration_summary",
                 "actor_id",
+                "actor_name",
                 "low_events",
                 "moderate_events",
                 "high_events",

--- a/src/_incydr_sdk/__version__.py
+++ b/src/_incydr_sdk/__version__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Code42 Software <integrations@code42.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "2.12.1"
+__version__ = "2.12.2"

--- a/src/_incydr_sdk/sessions/models/models.py
+++ b/src/_incydr_sdk/sessions/models/models.py
@@ -65,6 +65,7 @@ class Alert(Model):
     alert_id: Optional[str] = Field(alias="alertId")
     lesson_id: Optional[str] = Field(alias="lessonId")
     rule_id: Optional[str] = Field(alias="ruleId")
+    rule_name: Optional[str] = Field(None, alias="ruleName")
 
 
 class SessionsCriteriaRequest(BaseModel):

--- a/src/_incydr_sdk/sessions/models/response.py
+++ b/src/_incydr_sdk/sessions/models/response.py
@@ -20,6 +20,7 @@ class Session(ResponseModel):
     **Fields**:
 
     * **actor_id**: `str` The ID of the actor that generated the session.
+    * **actor_name**: `str` The name of the actor that generated the session.
     * **type**: `str` The type of the session.
     * **begin_time**: `datetime` The date and time when this session began.
     * **content_inspection_results**: `List[ContentInspectionResult]` The results of content inspection.
@@ -43,6 +44,7 @@ class Session(ResponseModel):
     """
 
     actor_id: Optional[str] = Field(None, alias="actorId")
+    actor_name: Optional[str] = Field(None, alias="actorName")
     type: Optional[str] = Field(None)
     begin_time: Optional[int] = Field(None, alias="beginTime")
     content_inspection_results: Optional[ContentInspectionResult] = Field(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -30,6 +30,7 @@ END_TIMESTAMP = 1734652800000  # in ms
 
 TEST_SESSION = {
     "actorId": TEST_SESSION_ID,
+    "actorName": "test_actor_name",
     "type": "STANDARD",
     "beginTime": POSIX_TS,
     "contentInspectionResults": {"detectedOnAlerts": ["PII"]},
@@ -66,7 +67,12 @@ TEST_SESSION = {
     ],
     "tenantId": "string",
     "triggeredAlerts": [
-        {"alertId": "alert-id", "lessonId": "lesson-id", "ruleId": "rule-id"}
+        {
+            "alertId": "alert-id",
+            "lessonId": "lesson-id",
+            "ruleId": "rule-id",
+            "ruleName": "rule name",
+        }
     ],
     "userId": "string",
 }


### PR DESCRIPTION
Changes are backwards-compatible, so we can merge this at any time even if the backend changes aren't ready yet.